### PR TITLE
chore(): Add Agentic Radar entry to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ We welcome contributions from the CrewAI community! If you've built an open-sour
 | Title                          | Description                               | Author                                   |
 |---------------------------------------|---------------------------------------|-----------------------------------------------|
 |         [BlogPostEditor](https://huggingface.co/spaces/Skier8402/crewai_article_editor)                  |     A duo of agents that helps you improve your blogpost.The `Senior Article Editor` agent aims to elevate blog posts to their highest potential by refining the content for clarity, coherence, and audience engagement while preserving the writer's unique voice. The `Article Researcher` agent focuses on simplifying the review process by fact-checking, evaluating source credibility, and ensuring the accuracy and relevance of the information presented in the blog post. In a Streamlit UI on Huggingface.   | [@Shuyib](https://github.com/Shuyib)                              |
+|         [Agentic Radar](https://github.com/splx-ai/agentic-radar)                  |     This CLI tool scans your source code locally, visualizes interactions between agents and tools in the CrewAI workflow, and tells you which known vulnerabilities (CVE and OWASP) do the tools being used have. It generates a complete HTML report with everything mentioned. A good tool to check for security issues before going to production.   | [@splx-ai](https://github.com/splx-ai)                              |
 
 ---
 ## Acknowledgments


### PR DESCRIPTION
This pull request adds a new project called "Agentic Radar" to the Apps/UI's section.

About the Project:
- This is a CLI tool that analyzes CrewAI workflows, identifies vulnerabilities, and generates an HTML report with visualizations.
- It doesn’t fully fit into the existing categories. Apps/UI was the best fit.

Question: Would it make sense to introduce a new category for CLI tools, security, or debugging?